### PR TITLE
Fix scrollbar changing contributor box width

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
         }
         .scrollable-contrib-list:hover, .scrollable-contrib-list:active, .scrollable-contrib-list:focus {
           overflow: auto;
+		  overflow-y: overlay;
         }
         .material-icons {
           outline: none!important;

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         }
         .scrollable-contrib-list:hover, .scrollable-contrib-list:active, .scrollable-contrib-list:focus {
           overflow: auto;
-		  overflow-y: overlay;
+          overflow-y: overlay;
         }
         .material-icons {
           outline: none!important;


### PR DESCRIPTION
Fixes behaviour in which hovering over the contributor box would cause the scrollbar to push the content in, in some cases causing word wrapping

**Before**

![image](https://user-images.githubusercontent.com/8270128/49049308-697e9980-f1d6-11e8-862d-7dfaf8ab9a72.png)

![image](https://user-images.githubusercontent.com/8270128/49049325-769b8880-f1d6-11e8-8fad-588a97338346.png)

**After**

![image](https://user-images.githubusercontent.com/8270128/49049358-9337c080-f1d6-11e8-9b97-4911b99d570f.png)
