### PR TITLE
Re-order the sidebar a little.

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,17 +208,27 @@
     </div>
     <div class="mdc-drawer__content">
       <nav class="mdc-list">
-        <a class="mdc-list-item mdc-list-item--activated" href="#" aria-selected="true">
-          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">memory</i>
-          <span class="mdc-list-item__text">Open Source</span>
+        <a class="mdc-list-item" href="./Site_Pages/About_Page.html">
+          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">people</i>
+          <span class="mdc-list-item__text">About Us</span>
         </a>
+        <a class="mdc-list-item" href="./Site_Pages/Disclaimer_Page.html">
+          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">chrome_reader_mode</i>
+          <span class="mdc-list-item__text">Disclaimer</span>
+        </a>
+        <a class="mdc-list-item" href="https://github.com/CyberDiscovery/cyberdiscovery.github.io">
+          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">memory</i>
+          <span class="mdc-list-item__text">Site Source</span>
+        </a>
+        <hr class="mdc-list-divider">
+        <h6 class="mdc-list-group__subheader">Official Links</h6>
         <a class="mdc-list-item" href="https://www.joincyberdiscovery.com/">
           <i class="material-icons mdc-list-item__graphic" aria-hidden="true">person_add</i>
-          <span class="mdc-list-item__text">Sign Up</span>
+          <span class="mdc-list-item__text">Registration</span>
         </a>
-        <a class="mdc-list-item" href="https://twitter.com/cyberdiscuk?lang=en">
+        <a class="mdc-list-item" href="https://twitter.com/cyberdiscuk">
           <i class="material-icons mdc-list-item__graphic" aria-hidden="true">share</i>
-          <span class="mdc-list-item__text">View Twitter</span>
+          <span class="mdc-list-item__text">Twitter Feed</span>
         </a>
         <a class="mdc-list-item" href="https://medium.com/cyber-discovery">
           <i class="material-icons mdc-list-item__graphic" aria-hidden="true">speaker_notes</i>
@@ -267,20 +277,6 @@
         <a class="mdc-list-item" href="https://ctftime.org/writeups">
           <i class="material-icons mdc-list-item__graphic" aria-hidden="true">library_books</i>
           <span class="mdc-list-item__text">CTF Writeups</span>
-        </a>
-        <hr class="mdc-list-divider">
-        <h6 class="mdc-list-group__subheader">Info</h6>
-        <a class="mdc-list-item" href="./Site_Pages/LICENSE.txt">
-          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">description</i>
-          <span class="mdc-list-item__text">View License</span>
-        </a>
-        <a class="mdc-list-item" href="./Site_Pages/Disclaimer_Page.html">
-          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">chrome_reader_mode</i>
-          <span class="mdc-list-item__text">Disclaimer</span>
-        </a>
-        <a class="mdc-list-item" href="./Site_Pages/About_Page.html">
-          <i class="material-icons mdc-list-item__graphic" aria-hidden="true">people</i>
-          <span class="mdc-list-item__text">About Us</span>
         </a>
       </nav>
     </div>


### PR DESCRIPTION
- Moved the on-site links to the top, above the off-site links
- Removed the link to LICENSE.txt, it's only really relevant with the
  source, in which case you have it anyway.
- Renamed a few things for consistency
- Added a header for official links to avoid confusion with the "Sign
  Up"