### PR TITLE
Remove Virtual Cyber School Date

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,11 +401,6 @@
                       <td class="mdc-data-table__cell">Q4 2017 - Q2 2021</td>
                       <td class="mdc-data-table__cell">Finished</td>
                     </tr>
-                    <tr class="mdc-data-table__row">
-                      <td class="mdc-data-table__cell">Virtual Cyber School</td>
-                      <td class="mdc-data-table__cell">31st August 2021</td>
-                      <td class="mdc-data-table__cell">Finished</td>
-                    </tr>
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
Remove the VCS entry on the dates table as it's no longer relevant and it's unlikely to mean anything to someone who stumbles across this page.

Signed-off-by: Yudhajit N <28938427+Sh3llcod3@users.noreply.github.com>